### PR TITLE
Punkduck devel

### DIFF
--- a/makeclothes/core_makeclothes_functionality.py
+++ b/makeclothes/core_makeclothes_functionality.py
@@ -221,28 +221,18 @@ class MakeClothes():
         if self.useMakeSkin:
             print("Using makeskin to write material")
             from makeskin import MHMat as MakeSkinMat
+
             mat = MakeSkinMat(self.clothesObj)
             outputFile = os.path.join(self.dirName, self.cleanedName + ".mhmat")
 
-            handling = "NORMALIZE"
-            if self.clothesObj.MhMsTextures:
-                handling = self.clothesObj.MhMsTextures
-            if handling == "NORMALIZE":
-                mat.copyTextures(outputFile)
-            if handling == "COPY":
-                mat.copyTextures(outputFile, normalize=False)
+            checkImg = mat.checkAllTexturesAreSaved()
+            if checkImg:
+                return (False, checkImg)
 
-            if mat.settings["normalmapTexture"]:
-                mat.shaderConfig["normal"] = True
-            if mat.settings["bumpmapTexture"]:
-                mat.shaderConfig["bump"] = True
-            if self.clothesObj.MhMsUseLit and self.clothesObj.MhMsLitsphere:
-                mat.litSphere = self.clothesObj.MhMsLitsphere
-            if mat.settings["displacementmapTexture"]:
-                mat.shaderConfig["displacement"] = True
+            errtext = mat.writeMHmat(self.clothesObj, outputFile)
+            if errtext:
+                return (False, checkImg)
 
-            with open(outputFile, 'w') as f:
-                f.write(str(mat))
         else:
             print("Using limited MakeClothes material model, ie not MakeSkin")
             (b, hint) = self.writeMhMat()

--- a/makeclothes/extraproperties.py
+++ b/makeclothes/extraproperties.py
@@ -14,6 +14,7 @@ _licenses.append(("CC-BY", "CC-BY", "Creative Commons Attribution",             
 _licenses.append(("AGPL",  "AGPL", "Affero Gnu Public License (don't use unless absolutely necessary)",     3))
 _licenseDescription = "Set an output license for the clothes. This will have no practical effect apart from being included in the written MHCLO file."
 
+_blendDescription = "Select human from blendfile"
 _tagsDescription = "Select Tags for MakeHuman"
 _tagsDescriptionAdd = "Enter Tags for MakeHuman, separate by comma"
 
@@ -31,6 +32,34 @@ _destination.append(("tongue", "tongue", "Tongue subdir", 6))
 _destination_description = "This is the subdirectory (under data) where we should put the produced clothes"
 
 mh_tags = {}
+mh_readitem = []
+
+def enumlist_meshes(self, context):
+    """Populate Mesh list"""
+    scene = context.scene
+    #
+    # do that once, otherwise we will read this file again and again!
+    # 
+    global mh_readitem
+
+    if len(mh_readitem) ==  0:
+        cnt = 0
+        blendpath = os.path.join(os.path.dirname(__file__), "humans")
+        if os.path.isdir(blendpath):
+            for filename in os.listdir(blendpath):
+                if filename.endswith(".blend"):
+                    filepath = os.path.join(blendpath, filename)
+
+                    with bpy.data.libraries.load(filepath) as (data_from, data_to):
+                        for obj in data_from.objects:
+                            if obj.startswith("mh_"):
+                                item = filename[:-6] + "-" + obj[3:]
+                                load = os.path.join(filepath,obj)
+                                mh_readitem.append((load, item, ""))
+                                cnt += 1
+        if cnt == 0:    # append dummy entry
+            mh_readitem.append(("---", "---", ""))
+    return mh_readitem
 
 def extraProperties():
     #
@@ -60,6 +89,7 @@ def extraProperties():
         setattr(bpy.types.Scene, 'MHTags_'+ group.lower(), EnumProperty(items=mh_tags[group], name=group.capitalize(),
                                                             description=_tagsDescription, default=mh_sel[group]))
 
+    bpy.types.Scene.MH_predefinedMeshes = bpy.props.EnumProperty(items=enumlist_meshes, name="Human", description=_blendDescription)
     bpy.types.Scene.MHAdditionalTags = bpy.props.StringProperty(name="Additional tags", description=_tagsDescriptionAdd, default="")
     bpy.types.Scene.MHClothesDestination = bpy.props.EnumProperty(items=_destination, name="Clothes destination", description=_destination_description, default="clothes")
     bpy.types.Scene.MHOverwrite = BoolProperty(name="Overwrite existent clothes", description="Must be marked, if you want to replace old files (.mhclo, .obj etc.)", default=False)

--- a/makeclothes/makeclothes2.py
+++ b/makeclothes/makeclothes2.py
@@ -37,7 +37,10 @@ class MHC_PT_MakeClothesPanel(bpy.types.Panel):
         humanBox = layout.box()
         humanBox.label(text="Human", icon="MESH_DATA")
         if not base_available:
-            humanBox.operator("makeclothes.importhuman", text="Import human")
+            if context.scene.MH_predefinedMeshes != "---":
+                humanBox.prop(context.scene, 'MH_predefinedMeshes')
+                humanBox.operator("makeclothes.importpredef", text="Import predefined human")
+            humanBox.operator("makeclothes.importhuman", text="Import human (.obj)")
 
         humanBox.operator("makeclothes.mark_as_human", text="Mark as human")
         humanBox.operator("makeclothes.check_human", text="Check human")

--- a/makeclothes/makeclothes2.py
+++ b/makeclothes/makeclothes2.py
@@ -3,6 +3,13 @@
 
 #  Author: Joel Palmius
 
+# layout:
+#
+# [preferences/common-settings]
+# [get & check human]
+# [get & check clothes]
+# [create clothes]
+
 import bpy
 
 class MHC_PT_MakeClothesPanel(bpy.types.Panel):
@@ -24,34 +31,10 @@ class MHC_PT_MakeClothesPanel(bpy.types.Panel):
 
         obj = context.active_object
 
-        setupBox = layout.box()
-        setupBox.label(text="Setup clothes mesh", icon="MESH_DATA")
-        setupBox.operator("makeclothes.mark_as_clothes", text="Mark as clothes")
-
-        setupBox.label(text="Vertex group as clothes:")
-        setupBox.operator("makeclothes.extract_clothes", text="Extract clothes")
-
-        setupBox.label(text="Edit existent clothes:")
-        setupBox.operator("makeclothes.import_mhclo", text="Import clothes file")
-
-        humanBox = layout.box()
-        humanBox.label(text="Human", icon="MESH_DATA")
-        if not base_available:
-            if context.scene.MH_predefinedMeshes != "---":
-                humanBox.prop(context.scene, 'MH_predefinedMeshes')
-                humanBox.operator("makeclothes.importpredef", text="Import predefined human")
-            humanBox.operator("makeclothes.importhuman", text="Import human (.obj)")
-
-        humanBox.operator("makeclothes.mark_as_human", text="Mark as human")
-        humanBox.operator("makeclothes.check_human", text="Check human")
-        humanBox.operator("makeclothes.delete_helper", text="Delete helpers")
-
-        checkBox = layout.box()
-        checkBox.label(text="Check clothes", icon="MESH_DATA")
-        checkBox.operator("makeclothes.check_clothes", text="Check clothes")
-
+        # common settings (always displayed)
+        #
         commonSettingsBox = layout.box()
-        commonSettingsBox.label(text="Common settings", icon="PRESET")
+        commonSettingsBox.label(text="Common settings", icon="TOOL_SETTINGS")
         col = commonSettingsBox.column()
         row = col.row()
         row.prop(scn, 'MHOverwrite', text="Overwrite existent files")
@@ -64,8 +47,40 @@ class MHC_PT_MakeClothesPanel(bpy.types.Panel):
         row.label(text="Author")
         row.prop(scn, 'MhClothesAuthor', text="")
 
+        # get and check human
+        #
+        humanBox = layout.box()
+        humanBox.label(text="Human", icon="MESH_DATA")
+        if not base_available:
+            if context.scene.MH_predefinedMeshes != "---":
+                humanBox.prop(context.scene, 'MH_predefinedMeshes')
+                humanBox.operator("makeclothes.importpredef", text="Import predefined human")
+            humanBox.operator("makeclothes.importhuman", text="Import human (.obj)")
+
+        humanBox.operator("makeclothes.mark_as_human", text="Mark as human")
+        humanBox.operator("makeclothes.check_human", text="Check human")
+        humanBox.operator("makeclothes.delete_helper", text="Delete helpers")
+
+        # get and check clothes (same order as human)
+        #
+        setupBox = layout.box()
+        setupBox.label(text="Clothes", icon="MESH_DATA")
+
+        setupBox.label(text="Vertex group as clothes:")
+        setupBox.operator("makeclothes.extract_clothes", text="Extract clothes")
+
+        setupBox.label(text="Edit existent clothes:")
+        setupBox.operator("makeclothes.import_mhclo", text="Import clothes file")
+
+        setupBox.operator("makeclothes.mark_as_clothes", text="Mark as clothes")
+
+        setupBox.operator("makeclothes.check_clothes", text="Check clothes")
+
+
+        # the procedure itself
+        #
         produceBox = layout.box()
-        produceBox.label(text="Produce clothes", icon="MESH_DATA")
+        produceBox.label(text="Produce clothes", icon="MOD_CLOTH")
         if obj is None or obj.type != "MESH":
             produceBox.label(text="- select a visible mesh object -")
         else:

--- a/makeclothes/operators/__init__.py
+++ b/makeclothes/operators/__init__.py
@@ -13,6 +13,7 @@ from .createclothes import MHC_OT_CreateClothesOperator
 from .checkhuman import MHC_OT_CheckHumanOperator
 from .deletehelper import MHC_OT_DeleteHelper
 from .tagselector import MHC_OT_TagSelector
+from .importpredef import MHC_OT_Predefined
 from .offsetscaling import MHC_OT_GetOffsetScaling
 
 OPERATOR_CLASSES = [
@@ -26,6 +27,7 @@ OPERATOR_CLASSES = [
     MHC_OT_CheckHumanOperator,
     MHC_OT_DeleteHelper,
     MHC_OT_TagSelector,
+    MHC_OT_Predefined,
     MHC_OT_GetOffsetScaling
 ]
 
@@ -40,6 +42,7 @@ __all__ = [
     "MHC_OT_CheckHumanOperator",
     "MHC_OT_DeleteHelper",
     "MHC_OT_TagSelector",
+    "MHC_OT_Predefined",
     "MHC_OT_GetOffsetScaling",
     "OPERATOR_CLASSES"
 ]

--- a/makeclothes/operators/importpredef.py
+++ b/makeclothes/operators/importpredef.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import bpy
+import os
+from .markashuman import markAsHuman
+
+class MHC_OT_Predefined(bpy.types.Operator):
+    """load predefined meshes from blend-file"""
+    bl_idname = "makeclothes.importpredef"
+    bl_label = "Import predefined human"
+    bl_options = {'REGISTER'}
+    @classmethod
+    def poll(cls, context):
+        return (context.scene.MH_predefinedMeshes != "---")
+
+    def execute(self, context):
+        oldnames = []
+        for obj in context.scene.objects:
+            oldnames.append (obj.name)
+        (filepath, obj) = os.path.split(context.scene.MH_predefinedMeshes)
+        print("append " + filepath + '/Object/' + obj)
+        bpy.ops.wm.append(directory=filepath + '/Object/', link=False, autoselect=True, filename=obj)
+
+        #
+        # get all objects and figure out the new mesh
+        #
+        newObj = None
+        for obj in context.scene.objects:
+            if obj.name not in oldnames:
+                newObj = obj
+                break
+
+        if newObj is not None:
+            context.view_layer.objects.active = newObj
+            text = markAsHuman(context)
+            self.report({'INFO'}, text)
+        return {'FINISHED'}
+

--- a/makeclothes/utils.py
+++ b/makeclothes/utils.py
@@ -16,7 +16,7 @@ from mathutils import Matrix
 from bpy_extras.io_utils import axis_conversion
 from io_scene_obj import import_obj
 
-LEAST_REQUIRED_MAKESKIN_VERSION = 20200116
+LEAST_REQUIRED_MAKESKIN_VERSION = 20200718
 _TRACING = True
 
 def getMyDocuments():


### PR DESCRIPTION
Pull request because of interface change to makeskin (for details see comment there)

Additionaly makeclothes accepts a directory "humans" inside makeclothes directory. This is a simple method to get a basemesh with one click, when no socket communication is running. The directory "humans" is scanned once, when blender starts, it contains blendfile(s). All meshes with a specific syntax are accepted and presented in blender then. For a test, I uploaded a file newmeshes.zip into development discussion (makeclothes, page 14), it contains two demo blend files which should be placed into this folder.  If directory "humans" is not available, makeclothes works like before. 

atm. I did not upload these blendfiles into github. That is because of pathes etc. It is not uncommon to have blendfiles in github. I checked for some blender tools like a new tree-generator etc. People also use blendfiles. Since we have to adapt our software, when blender changes, we can change blendfiles as well ...

I work with a version of T-posed and A-posed males and females and an additional female mesh with shape-key for high-heels which is applied before makeclothes  creates the shoes (inside MakeHuman high-heels target should be used) ...

I change the design a tiny bit. Makeskin and Makeclothes are quite similar now. Maybe licence/author should be handled also the same ... it is connected to scene in makeclothes and to object in makeskin

Next step should be some kind of integration of the 3 development tools .. (makeskin, clothes, target) .. 
