### PR TITLE
shapekeys/targets added, version number made visible

### DIFF
--- a/makeclothes/__init__.py
+++ b/makeclothes/__init__.py
@@ -4,30 +4,14 @@
 #  Authors: Joel Palmius
 #           black-punkduck
 
-# odd order has to be done not to get the title, is there a better way?
-
 from bpy.utils import register_class, unregister_class
-from .extraproperties import extraProperties, _globaltitle
-
-bl_info = {
-    "name": "MakeClothes",
-    "author": "Joel Palmius",
-    "version": (2,1,0),
-    "blender": (2,80,0),
-    "location": "View3D > Properties > Make Target",
-    "description": "Create MakeHuman Clothes",
-    'wiki_url': "http://www.makehumancommunity.org/",
-    "category": "MakeHuman"}
-
-
-extraproperties._globaltitle = bl_info["name"] + " v %d.%d.%d" % bl_info["version"]
-
-# now import rest with title set in MHC_PT_MakeClothesPanel
-#
+from .extraproperties import extraProperties, bl_info
 from .makeclothes2 import MHC_PT_MakeClothesPanel
 from .infobox import MHC_OT_InfoBox,MHC_WarningBox
 from .operators import *
 
+# bl_info is placed in extra-properties to have access from everywhere and to avoid
+# ending up with a circular dependency
 
 MAKECLOTHES2_CLASSES = []
 MAKECLOTHES2_CLASSES.extend(OPERATOR_CLASSES)

--- a/makeclothes/__init__.py
+++ b/makeclothes/__init__.py
@@ -4,11 +4,10 @@
 #  Authors: Joel Palmius
 #           black-punkduck
 
+# odd order has to be done not to get the title, is there a better way?
+
 from bpy.utils import register_class, unregister_class
-from .extraproperties import extraProperties
-from .makeclothes2 import MHC_PT_MakeClothesPanel
-from .infobox import MHC_OT_InfoBox,MHC_WarningBox
-from .operators import *
+from .extraproperties import extraProperties, _globaltitle
 
 bl_info = {
     "name": "MakeClothes",
@@ -19,6 +18,15 @@ bl_info = {
     "description": "Create MakeHuman Clothes",
     'wiki_url': "http://www.makehumancommunity.org/",
     "category": "MakeHuman"}
+
+
+extraproperties._globaltitle = bl_info["name"] + " v %d.%d.%d" % bl_info["version"]
+
+# now import rest with title set in MHC_PT_MakeClothesPanel
+#
+from .makeclothes2 import MHC_PT_MakeClothesPanel
+from .infobox import MHC_OT_InfoBox,MHC_WarningBox
+from .operators import *
 
 
 MAKECLOTHES2_CLASSES = []

--- a/makeclothes/__init__.py
+++ b/makeclothes/__init__.py
@@ -4,14 +4,24 @@
 #  Authors: Joel Palmius
 #           black-punkduck
 
+#
+# must be before(!) all imports
+#
+bl_info = {
+    "name": "MakeClothes",
+    "author": "Joel Palmius",
+    "version": (2,1,0),
+    "blender": (2,80,0),
+    "location": "View3D > Properties > Make Target",
+    "description": "Create MakeHuman Clothes",
+    'wiki_url': "http://www.makehumancommunity.org/",
+    "category": "MakeHuman"}
+
 from bpy.utils import register_class, unregister_class
-from .extraproperties import extraProperties, bl_info
+from .extraproperties import extraProperties
 from .makeclothes2 import MHC_PT_MakeClothesPanel
 from .infobox import MHC_OT_InfoBox,MHC_WarningBox
 from .operators import *
-
-# bl_info is placed in extra-properties to have access from everywhere and to avoid
-# ending up with a circular dependency
 
 MAKECLOTHES2_CLASSES = []
 MAKECLOTHES2_CLASSES.extend(OPERATOR_CLASSES)

--- a/makeclothes/extraproperties.py
+++ b/makeclothes/extraproperties.py
@@ -8,17 +8,6 @@ import json
 import os
 from bpy.props import BoolProperty, StringProperty, EnumProperty, IntProperty, CollectionProperty, FloatProperty
 
-bl_info = {
-    "name": "MakeClothes",
-    "author": "Joel Palmius",
-    "version": (2,1,0),
-    "blender": (2,80,0),
-    "location": "View3D > Properties > Make Target",
-    "description": "Create MakeHuman Clothes",
-    'wiki_url': "http://www.makehumancommunity.org/",
-    "category": "MakeHuman"}
-
-
 _licenses = []
 _licenses.append(("CC0",   "CC0", "Creative Commons Zero",                                                  1))
 _licenses.append(("CC-BY", "CC-BY", "Creative Commons Attribution",                                           2))

--- a/makeclothes/extraproperties.py
+++ b/makeclothes/extraproperties.py
@@ -8,6 +8,8 @@ import json
 import os
 from bpy.props import BoolProperty, StringProperty, EnumProperty, IntProperty, CollectionProperty, FloatProperty
 
+_globaltitle = ""       # title is filled by __init__
+
 _licenses = []
 _licenses.append(("CC0",   "CC0", "Creative Commons Zero",                                                  1))
 _licenses.append(("CC-BY", "CC-BY", "Creative Commons Attribution",                                           2))

--- a/makeclothes/extraproperties.py
+++ b/makeclothes/extraproperties.py
@@ -8,7 +8,16 @@ import json
 import os
 from bpy.props import BoolProperty, StringProperty, EnumProperty, IntProperty, CollectionProperty, FloatProperty
 
-_globaltitle = ""       # title is filled by __init__
+bl_info = {
+    "name": "MakeClothes",
+    "author": "Joel Palmius",
+    "version": (2,1,0),
+    "blender": (2,80,0),
+    "location": "View3D > Properties > Make Target",
+    "description": "Create MakeHuman Clothes",
+    'wiki_url': "http://www.makehumancommunity.org/",
+    "category": "MakeHuman"}
+
 
 _licenses = []
 _licenses.append(("CC0",   "CC0", "Creative Commons Zero",                                                  1))

--- a/makeclothes/makeclothes2.py
+++ b/makeclothes/makeclothes2.py
@@ -11,7 +11,7 @@
 # [create clothes]
 
 import bpy
-from .extraproperties import bl_info   # to get information about version
+from . import bl_info   # to get information about version
 
 class MHC_PT_MakeClothesPanel(bpy.types.Panel):
     bl_label = bl_info["name"] + " v %d.%d.%d" % bl_info["version"]

--- a/makeclothes/makeclothes2.py
+++ b/makeclothes/makeclothes2.py
@@ -11,9 +11,10 @@
 # [create clothes]
 
 import bpy
+from .extraproperties import  _globaltitle      # way to get the title (name & version)
 
 class MHC_PT_MakeClothesPanel(bpy.types.Panel):
-    bl_label = "MakeClothes2"
+    bl_label = _globaltitle
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "MakeClothes2"
@@ -23,10 +24,13 @@ class MHC_PT_MakeClothesPanel(bpy.types.Panel):
         scn = context.scene
 
         base_available = False
+        shape_keys = False
         for obj in scn.objects:
             if hasattr(obj, "MhObjectType"):
                 if obj.MhObjectType == "Basemesh":
                     base_available = True
+                    if  obj.data.shape_keys is not None:
+                        shape_keys = True
                     break
 
         obj = context.active_object
@@ -60,6 +64,8 @@ class MHC_PT_MakeClothesPanel(bpy.types.Panel):
         humanBox.operator("makeclothes.mark_as_human", text="Mark as human")
         humanBox.operator("makeclothes.check_human", text="Check human")
         humanBox.operator("makeclothes.delete_helper", text="Delete helpers")
+        if  shape_keys:
+            humanBox.operator("makeclothes.apply_shapekeys", text="Apply targets")
 
         # get and check clothes (same order as human)
         #

--- a/makeclothes/makeclothes2.py
+++ b/makeclothes/makeclothes2.py
@@ -11,10 +11,10 @@
 # [create clothes]
 
 import bpy
-from .extraproperties import  _globaltitle      # way to get the title (name & version)
+from .extraproperties import bl_info   # to get information about version
 
 class MHC_PT_MakeClothesPanel(bpy.types.Panel):
-    bl_label = _globaltitle
+    bl_label = bl_info["name"] + " v %d.%d.%d" % bl_info["version"]
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "MakeClothes2"

--- a/makeclothes/operators/__init__.py
+++ b/makeclothes/operators/__init__.py
@@ -11,6 +11,7 @@ from .importhuman import MHC_OT_ImportHumanOperator
 from .checkclothes import MHC_OT_CheckClothesOperator
 from .createclothes import MHC_OT_CreateClothesOperator
 from .checkhuman import MHC_OT_CheckHumanOperator
+from .apply_shapekeys import MHC_OT_ApplyShapeKeysOperator
 from .deletehelper import MHC_OT_DeleteHelper
 from .tagselector import MHC_OT_TagSelector
 from .importpredef import MHC_OT_Predefined
@@ -25,6 +26,7 @@ OPERATOR_CLASSES = [
     MHC_OT_CheckClothesOperator,
     MHC_OT_CreateClothesOperator,
     MHC_OT_CheckHumanOperator,
+    MHC_OT_ApplyShapeKeysOperator,
     MHC_OT_DeleteHelper,
     MHC_OT_TagSelector,
     MHC_OT_Predefined,
@@ -40,6 +42,7 @@ __all__ = [
     "MHC_OT_CheckClothesOperator",
     "MHC_OT_CreateClothesOperator",
     "MHC_OT_CheckHumanOperator",
+    "MHC_OT_ApplyShapeKeysOperator",
     "MHC_OT_DeleteHelper",
     "MHC_OT_TagSelector",
     "MHC_OT_Predefined",

--- a/makeclothes/operators/apply_shapekeys.py
+++ b/makeclothes/operators/apply_shapekeys.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import bpy
+import os
+from ..utils import getClothesRoot
+
+class MHC_OT_ApplyShapeKeysOperator(bpy.types.Operator):
+    """Apply shapekeys"""
+    bl_idname = "makeclothes.apply_shapekeys"
+    bl_label = "Apply targets"
+    bl_options = {'REGISTER'}
+
+    @classmethod
+    def poll(self, context):
+        if context.active_object is not None:
+            if not hasattr(context.active_object, "MhObjectType"):
+                return False
+            if context.active_object.select_get():
+                if context.active_object.MhObjectType == "Basemesh":
+                    if context.active_object.data.shape_keys is not None:
+                        return True
+        return False
+
+    def execute(self, context):
+
+        humanObj = context.active_object
+
+        humanObj.shape_key_add(name=str(humanObj.active_shape_key.name)+"_applied", from_mix=True)
+        n = len (humanObj.data.shape_keys.key_blocks)
+        humanObj.active_shape_key_index = 0
+        for i in range(0, n):
+            bpy.ops.object.shape_key_remove(all=False)
+
+        return {'FINISHED'}
+

--- a/makeclothes/operators/importhuman.py
+++ b/makeclothes/operators/importhuman.py
@@ -31,5 +31,7 @@ class MHC_OT_ImportHumanOperator(bpy.types.Operator, ImportHelper):
         obj = loadObjFile(context, self.properties.filepath)
         if obj is not None:
             text = markAsHuman(context)
+            if hasattr(bpy.context.scene, "MhScaleMode"):
+                bpy.context.scene.MhScaleMode = "DECIMETER"
             self.report({'INFO'}, text)
         return {'FINISHED'}

--- a/makeclothes/operators/importpredef.py
+++ b/makeclothes/operators/importpredef.py
@@ -23,7 +23,8 @@ class MHC_OT_Predefined(bpy.types.Operator):
         bpy.ops.wm.append(directory=filepath + '/Object/', link=False, autoselect=True, filename=obj)
 
         #
-        # get all objects and figure out the new mesh
+        # get all objects and figure out the new mesh, set this to human and set scale
+        # to decimeter
         #
         newObj = None
         for obj in context.scene.objects:
@@ -34,6 +35,8 @@ class MHC_OT_Predefined(bpy.types.Operator):
         if newObj is not None:
             context.view_layer.objects.active = newObj
             text = markAsHuman(context)
+            if hasattr(bpy.context.scene, "MhScaleMode"):
+                bpy.context.scene.MhScaleMode = "DECIMETER"
             self.report({'INFO'}, text)
         return {'FINISHED'}
 


### PR DESCRIPTION
1: I added a new method for shapekeys. It now works with maketarget
   load a predefined human
   load a target from makehuman
   either apply target new button or produce clothes then it will be applied
   (e.g. for heels or breast-size)
   this is the method without MPFB

2: when a mesh is loaded (obj or predefined mesh) and MPFB is available
   MhScaleMode now is set to DECIMETER

3: I generate the title from bl_info. It is a hack. bl_label is set,
   when from x import y is called, I cannot directly set it in __init__
   because I cannot import from __init__ so I put it as a global into
   extra_properties, which has to be imported first ... this is ...
   kinda crude :( ... But I did not want to threw all the
   makeclothes2.py code into the __init__.py

4: no dependencies changed