### PR TITLE
fix issue for rigidMatch at vertex 0

### DIFF
--- a/makeclothes/core_makeclothes_functionality.py
+++ b/makeclothes/core_makeclothes_functionality.py
@@ -300,7 +300,7 @@ class MakeClothes():
         # In this method we will go through the vertexmatches and if needed switch which vertices are selected so that all
         # vertices belong to the same face.
         for vm in self.vertexMatches:
-            if not vm.exactMatch and not vm.rigidMatch:
+            if vm.exactMatch is None and vm.rigidMatch is None:
                 faceMatches = []
                 maxScore = 1
                 for i in [0, 1, 2]:
@@ -356,7 +356,7 @@ class MakeClothes():
 
     def findWeightsAndDistances(self):
         for vertexMatch in self.vertexMatches:
-            if not vertexMatch.exactMatch:
+            if vertexMatch.exactMatch is None:
                 # TODO: could be that further improvement like Thomas' mid vertex should be done
 
                 # To make the algorithm understandable I change our 3 vertices to triangle ABC and use Blender
@@ -438,7 +438,7 @@ class MakeClothes():
             f.write("clothesIdx,clVertX,clVertY,clVertZ,hIdx1,hVert1x,hVert1y,hVert1z,dist1,hIdx2,hVert2x,hVert2y,hVert2z,dist2,hIdx3,hVert3x,hVert3y,hVert3z,dist3,sumdist,dist1pct,dist2pct,dist3pct,medianX,medianY,medianZ,medDistX,medDistY,medDistZ\n")
             for vm in self.vertexMatches:
 
-                if not vm.exactMatch: # No need to debug exact matches
+                if vm.exactMatch is None: # No need to debug exact matches
                     f.write("%d,%.4f,%.4f,%.4f" % (vm.index, vm.x, vm.y, vm.z)) # clothes
                     sumdist = 0.0
                     dist = [0.0, 0.0, 0.0]
@@ -473,7 +473,7 @@ class MakeClothes():
 
     def selectHumanVertices(self):
         for vm in self.vertexMatches:
-            if not vm.exactMatch:
+            if vm.exactMatch is None:
                 for i in [0, 1, 2]:
                     idx = vm.closestHumanVertexIndices[i]
                     self.humanObj.data.vertices[idx].select = True


### PR DESCRIPTION
makeclothes throws strange errors, when an exact match happens at vertex 0.

As `not vm.exactMatch` evaluates to `True` if the `exactMatch` happens at index 0, this has to be replaced with a explicit check for `None` e.g. `vm.exactMatch is None`.

I hope just creating this pull request is allowed, if an issue has to be created or other steps have to be taken first, then I'm already sorry.